### PR TITLE
Support .astro files class

### DIFF
--- a/queries/astro/class.scm
+++ b/queries/astro/class.scm
@@ -1,1 +1,1 @@
-; inherits: html, tsx
+; inherits: html, tsx, astro

--- a/queries/astro/class.scm
+++ b/queries/astro/class.scm
@@ -1,1 +1,7 @@
 ; inherits: html, tsx, astro
+
+(attribute
+  (attribute_name) @_attribute_name
+  (#eq? @_attribute_name "class")
+  (quoted_attribute_value
+    (attribute_value) @_class_value))

--- a/queries/astro/class.scm
+++ b/queries/astro/class.scm
@@ -1,7 +1,1 @@
-; inherits: html, tsx, astro
-
-(attribute
-  (attribute_name) @_attribute_name
-  (#eq? @_attribute_name "class")
-  (quoted_attribute_value
-    (attribute_value) @_class_value))
+; inherits: tsx


### PR DESCRIPTION
It seems to bug when we try to inherits few.
The tsx one does already all types so I just keep that one and now it works in `.astro` file too! 😄 