### PR TITLE
fix: guard against nil result

### DIFF
--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -104,6 +104,7 @@ M.color_request = function(bufnr)
 
   client.request("textDocument/documentColor", params, function(err, result, _, _)
     if err then return log.error(err.message) end
+    if not result then return end
     if not vim.api.nvim_buf_is_valid(bufnr) then return end
 
     ---@type lsp.ColorInformation[]


### PR DESCRIPTION
On some files, tailwind-tools spams me with a ton of messages like this:

```
Error: Error executing vim.schedule lua callback: ...nvim/lazy/tailwind-tools.nvim/lua/tailwind-tools/lsp.lua:113: bad argument #1 to 'pairs' (table expected, got nil) 
stack traceback:
	[C]: in function 'pairs'
	...nvim/lazy/tailwind-tools.nvim/lua/tailwind-tools/lsp.lua:113: in function 'handler'
	...t_viLObvdF/usr/share/nvim/runtime/lua/vim/lsp/client.lua:692: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

I'm not sure what the exact root cause is, but `result` in `textDocument/documentColor` is `nil`.

Sidenote, this happens in a plain Node.js backend project, no tailwind in use in this case, it does work great in the react frontend codebase with tailwind though :grin: :+1: 