### PR TITLE
fix: set `state`s values on `setup()`.

### DIFF
--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -11,6 +11,9 @@ local motions = require("tailwind-tools.motions")
 M.setup = function(options)
   config.options = vim.tbl_deep_extend("keep", options, config.options)
 
+  state.conceal.enabled = config.options.conceal.enabled
+  state.color.enabled = config.options.document_color.enabled
+
   if vim.version().minor < 10 and config.options.document_color.kind == "inline" then
     log.warn(
       "Neovim nightly is required for inline color hints, using fallback option."

--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -46,14 +46,12 @@ M.setup = function(options)
     callback = lsp.on_attach,
   })
 
-  if config.options.conceal.enabled then
-    vim.api.nvim_create_autocmd("BufEnter", {
-      group = vim.g.tailwind_tools.conceal_au,
-      callback = function()
-        if state.conceal.enabled then conceal.enable() end
-      end,
-    })
-  end
+  vim.api.nvim_create_autocmd("BufEnter", {
+    group = vim.g.tailwind_tools.conceal_au,
+    callback = function()
+      if state.conceal.enabled then conceal.enable() end
+    end,
+  })
 end
 
 return M

--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -50,7 +50,7 @@ M.setup = function(options)
     vim.api.nvim_create_autocmd("BufEnter", {
       group = vim.g.tailwind_tools.conceal_au,
       callback = function()
-        if not state.conceal.enabled then conceal.enable() end
+        if state.conceal.enabled then conceal.enable() end
       end,
     })
   end

--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -92,7 +92,9 @@ M.on_attach = function(args)
     end,
   })
 
-  M.color_request(bufnr)
+  if state.color.enabled then
+    M.color_request(bufnr)
+  end
 end
 
 ---@param bufnr number

--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -92,9 +92,7 @@ M.on_attach = function(args)
     end,
   })
 
-  if state.color.enabled then
-    M.color_request(bufnr)
-  end
+  if state.color.enabled then M.color_request(bufnr) end
 end
 
 ---@param bufnr number

--- a/lua/tailwind-tools/state.lua
+++ b/lua/tailwind-tools/state.lua
@@ -1,5 +1,3 @@
-local config = require("tailwind-tools.config")
-
 return {
   conceal = {
     enabled = false,
@@ -7,7 +5,7 @@ return {
   },
   color = {
     request_timer = nil,
-    enabled = config.options.document_color.enabled,
+    enabled = false,
     active_buffers = {},
   },
 }


### PR DESCRIPTION
Previously, the `state` table values wasn't being updated with the values provided from the `config` table, which forced to manually run `Tailwind{Conceal,Color}{Disable,Enable}` to actually active/deactivate the specific features.

This also fixes minor boolean logic for `conceal.enabled` auto-command.

---

As a side note, is the _outer_ `if` really needed?

https://github.com/luckasRanarison/tailwind-tools.nvim/blob/87b507e7ae1d496f4a6071546ac83b6e67373e04/lua/tailwind-tools/init.lua#L46-L53

Wouldn't it be the same to just create the auto-command unconditionally, since the `callback` already checks if `conceal` is enabled? Maybe I'm missing something, so I'm gonna leave it as it is :sweat_smile:.