### PR TITLE
Fixes issue with plugin closing new tabs opened with telescope-helpgrep.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Here is the default configuration:
     },
   },
   custom_filetypes = {} -- see the extension section to learn how it works
+  supported_filetypes = {
+    "html",
+    "css",
+    "php",
+    "twig",
+    "vue",
+    "svelte",
+    "astro",
+    "htmldjango",
+    "javascriptreact",
+    "typescriptreact",
+  
 }
 ```
 

--- a/lua/tailwind-tools/conceal.lua
+++ b/lua/tailwind-tools/conceal.lua
@@ -36,11 +36,13 @@ end
 M.enable = function()
   vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
     group = vim.g.tailwind_tools.conceal_au,
+    pattern = config.options.supported_filetypes,
     callback = function(args) set_conceal(args.buf) end,
   })
   -- Workaround to reset conceallevel per buffer
   vim.api.nvim_create_autocmd("BufEnter", {
     group = vim.g.tailwind_tools.conceal_au,
+    pattern = config.options.supported_filetypes,
     callback = function(args)
       vim.wo.conceallevel = vim.opt.conceallevel:get()
       if state.conceal.enabled then set_conceal(args.buf) end

--- a/lua/tailwind-tools/config.lua
+++ b/lua/tailwind-tools/config.lua
@@ -20,6 +20,18 @@ M.options = {
     },
   },
   custom_filetypes = {},
+  supported_filetypes = {
+    "html",
+    "css",
+    "php",
+    "twig",
+    "vue",
+    "svelte",
+    "astro",
+    "htmldjango",
+    "javascriptreact",
+    "typescriptreact",
+  },
 }
 
 return M

--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -43,6 +43,7 @@ M.setup = function(options)
 
   vim.api.nvim_create_autocmd("LspAttach", {
     group = vim.g.tailwind_tools.conceal_au,
+    pattern = config.options.supported_filetypes,
     callback = lsp.on_attach,
   })
 

--- a/lua/tailwind-tools/treesitter.lua
+++ b/lua/tailwind-tools/treesitter.lua
@@ -4,24 +4,12 @@ local log = require("tailwind-tools.log")
 local config = require("tailwind-tools.config")
 local parsers = require("nvim-treesitter.parsers")
 
-local supported_filetypes = {
-  "html",
-  "css",
-  "php",
-  "twig",
-  "vue",
-  "svelte",
-  "astro",
-  "htmldjango",
-  "javascriptreact",
-  "typescriptreact",
-}
-
 ---@param bufnr number
 ---@param all boolean?
 M.get_class_nodes = function(bufnr, all)
   local ft = vim.bo[bufnr].ft
-  local filetypes = vim.tbl_extend("keep", config.options.custom_filetypes, supported_filetypes)
+  local filetypes =
+    vim.tbl_extend("keep", config.options.custom_filetypes, config.options.supported_filetypes)
   local results = {}
 
   if not vim.tbl_contains(filetypes, ft) then return end


### PR DESCRIPTION
I am the maintainer of telescope-helpgrep.nvim (https://github.com/catgoose/telescope-helpgrep.nvim), when I have the default action set to `telescope.actions.select_tab` the autocmds setup for `tailwind-tools.nvim` automatically close the tab created by Telescope.

I have added supported_filetypes to the config and used those filetypes as patterns in the autocmds