### PR TITLE
Fixed javascript, javascriptreact, typescript and typescriptreact file types.

### DIFF
--- a/queries/javascript/class.scm
+++ b/queries/javascript/class.scm
@@ -1,3 +1,5 @@
+; inherits: tsx
+
 (call_expression
   function: [
     (identifier) @ident
@@ -11,14 +13,4 @@
       (_)+) @tailwind ; the actual class range is extracted in the code
     (template_string
       (string_fragment) @tailwind)
-  ])
-
-(jsx_attribute
-  (property_identifier) @_attribute_name
-  (#any-of? @_attribute_name "class" "className" "style" "css" "tw")
-  [
-    (string
-      (string_fragment) @tailwind)
-    (jsx_expression
-      (_) @tailwind)
   ])

--- a/queries/javascript/class.scm
+++ b/queries/javascript/class.scm
@@ -12,3 +12,13 @@
     (template_string
       (string_fragment) @tailwind)
   ])
+
+(jsx_attribute
+  (property_identifier) @_attribute_name
+  (#any-of? @_attribute_name "class" "className" "style" "css" "tw")
+  [
+    (string
+      (string_fragment) @tailwind)
+    (jsx_expression
+      (_) @tailwind)
+  ])

--- a/queries/typescript/class.scm
+++ b/queries/typescript/class.scm
@@ -1,1 +1,14 @@
-; inherits: javascript
+(call_expression
+  function: [
+    (identifier) @ident
+    (member_expression
+      object: (identifier) @object-ident)
+  ]
+  (#any-of? @ident "clsx" "classnames" "tw" "css")
+  (#eq? @object-ident "tw")
+  arguments: [
+    (arguments
+      (_)+) @tailwind ; the actual class range is extracted in the code
+    (template_string
+      (string_fragment) @tailwind)
+  ])

--- a/tests/parsers.lua
+++ b/tests/parsers.lua
@@ -11,6 +11,7 @@ local parsers = {
   "heex",
   "elixir",
   "javascript",
+  "typescript",
   "templ",
 }
 

--- a/tests/queries/javascript/Component.jsx
+++ b/tests/queries/javascript/Component.jsx
@@ -1,0 +1,23 @@
+const color = "text-blue-300";
+
+const Component = () => {
+  return (
+    <div>
+      <div
+        className="flex items-center justify-center container mx-auto p-4
+        border-2 border-gray-500 rounded-md bg-gray-100"
+      >
+        <div className="text-2xl font-bold mb-4">
+          Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint
+          cillum sint consectetur cupidatat.
+        </div>
+        <div className={`${color} bg-gray-100`}>
+          Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint
+          cillum sint consectetur cupidatat.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Component;

--- a/tests/queries/javascript_spec.lua
+++ b/tests/queries/javascript_spec.lua
@@ -1,4 +1,6 @@
-require("tests.queries.runner").test({
+local runner = require("tests.queries.runner")
+
+runner.test({
   name = "javascript",
   provider = "treesitter",
   file = "tests/queries/javascript/test.js",
@@ -7,5 +9,16 @@ require("tests.queries.runner").test({
     { 1, 11, 1, 36 },
     { 2, 3, 2, 20 },
     { 3, 9, 3, 34 },
+  },
+})
+
+runner.test({
+  name = "javascriptreact",
+  provider = "treesitter",
+  file = "tests/queries/javascript/Component.jsx",
+  ranges = {
+    { 6, 19, 7, 55 },
+    { 9, 24, 9, 47 },
+    { 13, 24, 13, 46 },
   },
 })

--- a/tests/queries/typescript/test.ts
+++ b/tests/queries/typescript/test.ts
@@ -1,0 +1,4 @@
+clsx("p-4", "text-center");
+classnames("bg-red-500", "uppercase");
+tw`font-mono text-sm`
+tw.input`border hover:border-black`

--- a/tests/queries/typescript_spec.lua
+++ b/tests/queries/typescript_spec.lua
@@ -1,0 +1,11 @@
+require("tests.queries.runner").test({
+  name = "typescript",
+  provider = "treesitter",
+  file = "tests/queries/typescript/test.ts",
+  ranges = {
+    { 0, 5, 0, 25 },
+    { 1, 11, 1, 36 },
+    { 2, 3, 2, 20 },
+    { 3, 9, 3, 34 },
+  },
+})


### PR DESCRIPTION
The master branch of the extension contains an error when handling javascript, javascriptreact, typescript and typescriptreact file types. The issue lies in the  ```/queries/typescript/class.scm``` file, which inherits its configuration from the ```queries/javascript/class.scm``` file. This causes the class concealing functionality to malfunction in  javascriptreact files.


# Images to Illustrate the Issue

##  Extension configuration
![image](https://github.com/user-attachments/assets/34848079-a6dc-4659-b9a9-dec24cb33c6c)


## Working in typescriptreact
![image](https://github.com/user-attachments/assets/bb1e0c54-d1ea-46c1-93e5-f65069165e6e)


## Working in javascriptreact
![image](https://github.com/user-attachments/assets/7dfbd5be-51a4-4cab-8a88-1d43af86d5ef)

The solution to this error is to explicitly specify the file types in ```queries/javascript/class.scm```
```
(call_expression
  function: [
    (identifier) @ident
    (member_expression
      object: (identifier) @object-ident)
  ]
  (#any-of? @ident "clsx" "classnames" "tw" "css")
  (#eq? @object-ident "tw")
  arguments: [
    (arguments
      (_)+) @tailwind ; the actual class range is extracted in the code
    (template_string
      (string_fragment) @tailwind)
  ])

(jsx_attribute
  (property_identifier) @_attribute_name
  (#any-of? @_attribute_name "class" "className" "style" "css" "tw")
  [
    (string
      (string_fragment) @tailwind)
    (jsx_expression
      (_) @tailwind)
  ])
```

# Images to illustrate the solution


##  Extension configuration
![image](https://github.com/user-attachments/assets/4c1f497e-87c1-4af3-b9b4-8e27d38163f3)


## Working in typescriptreact
![image](https://github.com/user-attachments/assets/01f4c54d-06ac-4065-b5bb-c1802e6b85e6)


## Working in javascriptreact
![image](https://github.com/user-attachments/assets/c295fa53-cba3-4d17-bff0-95d7fabfe36a)
