### PR TITLE
fix: bug where plugin errors if options is nil

### DIFF
--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -9,7 +9,7 @@ local motions = require("tailwind-tools.motions")
 
 ---@param options TailwindTools.Option
 M.setup = function(options)
-  config.options = vim.tbl_deep_extend("keep", options, config.options)
+  config.options = vim.tbl_deep_extend("keep", options or {}, config.options)
 
   state.conceal.enabled = config.options.conceal.enabled
   state.color.enabled = config.options.document_color.enabled


### PR DESCRIPTION
If calling setup like this 
```lua
  config = function() 
      require("tailwind-tools").setup() 
  end,
``` 
the plugin will error if the `options` parameter in setup is nil, 

This fix will make it so `options` defaults to empty table if nil