### PR TITLE
Add option to config that allows for changing of highlight in the cmp menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Here is the default configuration:
       fg = "#38BDF8",
     },
   },
+  cmp = {
+    highlight = "foreground" -- highlight either bg or fg of text in color previews in cmp menu. can be "foreground" | "background"
+  }
   telescope = {
     utilities = {
       -- the function used when selecting an utility class in telescope

--- a/lua/tailwind-tools/cmp.lua
+++ b/lua/tailwind-tools/cmp.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local config = require("tailwind-tools.config")
 local utils = require("tailwind-tools.utils")
 
 -- Formatting utility for https://github.com/onsails/lspkind.nvim
@@ -12,6 +13,13 @@ M.lspkind_format = function(entry, vim_item)
   if vim_item.kind == "Color" and doc then
     local content = type(doc) == "string" and doc or doc.value
     local r, g, b = utils.extract_color(content)
+
+    if config.options.cmp.highlight == "background" then
+      if r then
+        vim_item.kind_hl_group = utils.set_hl_from(r, g, b, "background")
+        return vim_item
+      end
+    end
 
     if r then vim_item.kind_hl_group = utils.set_hl_from(r, g, b, "foreground") end
   end

--- a/lua/tailwind-tools/cmp.lua
+++ b/lua/tailwind-tools/cmp.lua
@@ -14,7 +14,7 @@ M.lspkind_format = function(entry, vim_item)
     local content = type(doc) == "string" and doc or doc.value
     local r, g, b = utils.extract_color(content)
 
-    local style = config.option.cmp.highlight
+    local style = config.options.cmp.highlight
     if r then vim_item.kind_hl_group = utils.set_hl_from(r, g, b, style) end
   end
 

--- a/lua/tailwind-tools/cmp.lua
+++ b/lua/tailwind-tools/cmp.lua
@@ -14,14 +14,8 @@ M.lspkind_format = function(entry, vim_item)
     local content = type(doc) == "string" and doc or doc.value
     local r, g, b = utils.extract_color(content)
 
-    if config.options.cmp.highlight == "background" then
-      if r then
-        vim_item.kind_hl_group = utils.set_hl_from(r, g, b, "background")
-        return vim_item
-      end
-    end
-
-    if r then vim_item.kind_hl_group = utils.set_hl_from(r, g, b, "foreground") end
+    local style = config.option.cmp.highlight
+    if r then vim_item.kind_hl_group = utils.set_hl_from(r, g, b, style) end
   end
 
   return vim_item

--- a/lua/tailwind-tools/config.lua
+++ b/lua/tailwind-tools/config.lua
@@ -3,6 +3,7 @@
 local M = {}
 
 ---@alias TailwindTools.ColorHint "foreground" | "background" | "inline"
+---@alias TailwindTools.CmpHighlightHint "foreground" | "background"
 
 ---@class TailwindTools.Option
 M.options = {
@@ -20,6 +21,10 @@ M.options = {
     highlight = {
       fg = "#38BDF8",
     },
+  },
+  cmp = {
+    ---@type TailwindTools.CmpHighlightHint
+    highlight = "foreground",
   },
   telescope = {
     utilities = {


### PR DESCRIPTION
Adds a config option `cmp` with a sub-opt `highlight` that can take either `foreground` or `background` to determine what should be highlighted in the cmp menu if the users has the cmp formatting enabled.

The config's default is `foreground` as to not cause a "breaking" appearance

here's a preview of what the highlighting will look like
![image](https://github.com/user-attachments/assets/680a7bac-8f24-4a4c-bc2d-723c7d8208cd)

