### PR TITLE
feat: extend list of lspconfig "root_dir" paths 

### DIFF
--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -137,11 +137,8 @@ M.setup = function(opts, lspconfig)
       includeLanguages = filetypes.get_server_map(),
     },
     root_dir = lspconfig.util.root_pattern(
-      "tailwind.config.js",
-      "tailwind.config.cjs",
-      "tailwind.config.mjs",
-      "tailwind.config.ts",
-      ".git"
+      "tailwind.config.{js,cjs,mjs,ts}",
+      "assets/tailwind.config.{js,cjs,mjs,ts}"
     ),
   })
 end

--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -140,7 +140,8 @@ M.setup = function(opts, lspconfig)
       "tailwind.config.js",
       "tailwind.config.cjs",
       "tailwind.config.mjs",
-      "tailwind.config.ts"
+      "tailwind.config.ts",
+      ".git"
     ),
   })
 end


### PR DESCRIPTION
### Problem

I decided to try out this plugin, and as recommended by the documentation, I switched from managing the `lspconfig` configuration for `tailwindcss` on my own, to letting this plugin manage setting up the server with `lspconfig`.

Currently the configuration options that are provided to `lspconfig.tailwindcss.setup` has the key for `root_dir` hardcoded, unlike the `settings` key which one can supply in the configuration for `tailwind-tools.nvim`. This can be seen here:

https://github.com/luckasRanarison/tailwind-tools.nvim/blob/41e901e7b4470082b5388b8385249632642c2510/lua/tailwind-tools/lsp.lua#L139-L144

The list of paths/filenames that can be seen in the link above has the problem that it does not work with projects that store the `tailwind.config.js` (or a variant with some other allowed file extension) somewhere else than in the root of the project. [Phoenix](https://www.phoenixframework.org/), which is the framework in which I encountered this problem, places the `tailwind.config.js` in `assets/`, resulting in the root not being found, and in turn the server not being loaded properly. Placing a symlink in the root directory to the `tailwind.config.js` resulted in the server loading.

### Solution

I would guess that there may be problems with allowing the configuration of the list of paths/filenames that are passed to `lspconfig.util.root_pattern`, although maybe I'm wrong and this is totally fine. This would, however, necessitate changing the code to allow for the injection of this configuration, which is a non-trivial change (even though I suspect much code could be reused from the code that allows the injection of `settings`).

An easier solution would be to look at what `nvim-lspconfig` does, with respect to `root_dir` for `tailwindcss`:

https://github.com/neovim/nvim-lspconfig/blob/b064131428f6bbbbc905f4451ba6779fda334a3a/lua/lspconfig/server_configurations/tailwindcss.lua#L126-L128

Those defaults check for 4 more things than this project:

1. `postcss.config.{js,cjs,mjs,ts}`
2. `package.json`
3. `node_modules`
4. `.git`

Again, the first 3 in this list would be placed in `assets/` in a Phoenix project. The last one, however, would be in the root. It's my guess that `.git` is the most general, and would therefore be the easy addition that would make more projects work out-of-the-box.