### PR TITLE
fix: pass full server opts to lsp.setup

### DIFF
--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -77,7 +77,7 @@ M.setup = function(options)
   local has_lspconfig, lspconfig = pcall(require, "lspconfig")
 
   if has_telescope then telescope.load_extension("tailwind") end
-  if has_lspconfig and server_opts.override then lsp.setup(server_opts.settings, lspconfig) end
+  if has_lspconfig and server_opts.override then lsp.setup(server_opts, lspconfig) end
 
   register_usercmd()
   register_autocmd()


### PR DESCRIPTION
I was trying to pass my own `server.on_attach` function but it wasn't working. It turns out `tailwind-tools` passes `server.settings` to `lsp.setup` but it expects the whole `server` object.

This PR fixes that. Related: https://github.com/neovim/nvim-lspconfig/issues/3415