### PR TITLE
Update Elixir filetype mappings to Tailwind server names

### DIFF
--- a/lua/tailwind-tools/filetypes.lua
+++ b/lua/tailwind-tools/filetypes.lua
@@ -28,11 +28,12 @@ local filetypes = {
     rust = { "class[=:]%s*[\"']([^\"']+)[\"']" },
   },
   server = {
+    elixir = "phoenix-heex",
     eelixir = "html-eex",
     eruby = "erb",
     templ = "html",
     rust = "html",
-    heex = "html",
+    heex = "phoenix-heex",
   },
 }
 


### PR DESCRIPTION
Referencing https://github.com/tailwindlabs/tailwindcss-intellisense/blob/5ffa254c4d239747755283795f91209296303c15/packages/tailwindcss-language-service/src/util/languages.ts#L31

This updates some vim filetypes to the corresponding tailwind ls values.