### PR TITLE
Allow extending server config

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,7 +1,9 @@
 {
+  "diagnostics.globals": ["vim"],
+  "diagnostics.unusedLocalExclude": ["_*"],
   "runtime.version": "LuaJIT",
   "workspace.library": [
-    "/usr/local/share/nvim/runtime/lua",
+    "$VIMRUNTIME",
     "~/.local/share/nvim/lazy/nvim-cmp",
     "~/.local/share/nvim/lazy/telescope.nvim",
     "~/.local/share/nvim/lazy/nvim-lspconfig",

--- a/README.md
+++ b/README.md
@@ -82,7 +82,17 @@ Here is the default configuration:
 {
   server = {
     override = true, -- setup the server from the plugin if true
-    settings = {}, -- shortcut for `settings.tailwindCSS`
+    settings = { -- shortcut for `settings.tailwindCSS`
+      -- experimental = {
+      --   classRegex = { "tw\\('([^']*)'\\)" }
+      -- },
+      -- includeLanguages = {
+      --   elixir = "phoenix-heex",
+      --   heex = "phoenix-heex",
+      -- },
+    },
+    on_attach = function(client, bufnr) end, -- callback executed when the language server gets attached to a buffer
+    root_dir = function(fname) end, -- overrides the default function for resolving the root directory
   },
   document_color = {
     enabled = true, -- can be toggled by commands
@@ -110,55 +120,10 @@ Here is the default configuration:
   extension = {
     queries = {}, -- a list of filetypes having custom `class` queries
     patterns = { -- a map of filetypes to Lua pattern lists
-      -- example:
       -- rust = { "class=[\"']([^\"']+)[\"']" },
       -- javascript = { "clsx%(([^)]+)%)" },
     },
   },
-}
-```
-
-If you have other LSP settings that you typically set, for example you need to
-supply the LSP server a `root_dir` function, or you have keymaps to set when
-the LSP attaches with `on_attach`, you can provide these through
-tailwind-tools config:
-
-```lua
-{
-  server = {
-    root_dir = function(fname)
-      -- For example:
-      -- Try defaults first, but if not found, then try my custom function
-      local lspconfig = require('lspconfig')
-      local root_file = require('tailwind-tools.lsp').make_root_dir(lspconfig)(fname)
-      if root_file then return root_file end
-
-      local path = vim.fn.fnamemodify(fname, ':h')
-      local mix_lock_dir = vim.fs.dirname(vim.fs.find('mix.lock', { path = path, upward = true })[1])
-      if mix_lock_dir then
-        local path_sep = iswin and '\\' or '/'
-        for line in io.lines(mix_lock_dir .. path_sep .. 'mix.lock') do
-          if line:find('"tailwind"') then
-            root_file = 'mix.exs'
-            break
-          end
-        end
-      end
-
-      return root_file
-    end,
-
-    -- TailwindTools will additionally run its own function during on_attach
-    on_attach = require('me.lsp').on_attach,
-
-    -- TailwindTools will merge this with default filetype to server mappings
-    settings = {
-      includeLanguages = {
-        elixir = "phoenix-heex",
-        heex = "phoenix-heex",
-      }
-    }
-  }
 }
 ```
 

--- a/lua/tailwind-tools/conceal.lua
+++ b/lua/tailwind-tools/conceal.lua
@@ -52,7 +52,7 @@ M.enable = function()
   end
 
   -- Restore color hints
-  if state.color.enabled then lsp.color_request(0) end
+  if state.color.enabled then lsp.color_request(nil, 0) end
 
   state.conceal.enabled = true
 end
@@ -70,7 +70,7 @@ M.disable = function()
     end
   end
 
-  if state.color.enabled then lsp.color_request(0) end
+  if state.color.enabled then lsp.color_request(nil, 0) end
 
   state.conceal.active_buffers = {}
   state.conceal.enabled = false

--- a/lua/tailwind-tools/config.lua
+++ b/lua/tailwind-tools/config.lua
@@ -4,14 +4,57 @@ local M = {}
 
 ---@alias TailwindTools.ColorHint "foreground" | "background" | "inline"
 ---@alias TailwindTools.CmpHighlightHint "foreground" | "background"
+---@alias TailwindTools.SettingsOption.DiagnosticSeveritySetting "ignore" | "warning" | "error"
+
+---@class TailwindTools.SettingsOption.LintOption
+---@field cssConflict? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field invalidApply? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field invalidScreen? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field invalidVariant? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field invalidConfigPath? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field invalidTailwindDirective? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field invalidSourceDirective? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+---@field recommendedVariantOrder? TailwindTools.SettingsOption.DiagnosticSeveritySetting
+
+---@class TailwindTools.SettingsOption.ExperimentalOption
+---@field classRegex? string[] | [string, string][]
+---@field configFile? string | {[string]: string | string[]}
+
+---@class TailwindTools.SettingsOption.FilesOption
+---@field exclude? string[]
+
+---@class TailwindTools.ServerOption
+---@field override boolean
+---@field settings TailwindTools.SettingsOption
+---@field on_attach? vim.lsp.client.on_attach_cb
+---@field root_dir? fun(fname: string): string | nil
+---@field capabilities vim.lsp.ClientCapabilities
+
+---@class TailwindTools.SettingsOption
+---@field tailwindCSS? TailwindTools.SettingsOption
+---@field inspectPort? number
+---@field emmetCompletions? boolean
+---@field includeLanguages? { [string]: string }
+---@field classAttributes? string[]
+---@field classFunctions? string[]
+---@field suggestions? boolean
+---@field hovers? boolean
+---@field codeLens? boolean
+---@field codeActions? boolean
+---@field validate? boolean
+---@field showPixelEquivalents? boolean
+---@field rootFontSize? number
+---@field colorDecorators? boolean
+---@field lint? TailwindTools.SettingsOption.LintOption
+---@field experimental? TailwindTools.SettingsOption.ExperimentalOption
+---@field files? TailwindTools.SettingsOption.FilesOption
 
 ---@class TailwindTools.Option
+---@field server TailwindTools.ServerOption
 M.options = {
-  ---@class TailwindTools.ServerOption
   server = {
     override = true,
     settings = {},
-    on_attach = function(_client, _bufnr) end,
   },
   document_color = {
     enabled = true,

--- a/lua/tailwind-tools/init.lua
+++ b/lua/tailwind-tools/init.lua
@@ -29,7 +29,7 @@ local function register_autocmd()
 
   autocmd("LspAttach", {
     group = vim.g.tailwind_tools.color_au,
-    callback = lsp.on_attach,
+    callback = lsp.on_attach_cb,
   })
 
   autocmd("BufEnter", {
@@ -42,7 +42,7 @@ local function register_autocmd()
   autocmd("Colorscheme", {
     group = vim.g.tailwind_tools.color_au,
     callback = function()
-      lsp.color_request(0)
+      lsp.color_request(nil, 0)
       vim.api.nvim_set_hl(0, "TailwindConceal", config.options.conceal.highlight)
     end,
   })

--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -123,7 +123,7 @@ end
 M.setup = function(server_config, lspconfig)
   local conf = { settings = {} }
   conf.on_attach = M.make_on_attach(server_config.on_attach)
-  conf.root_dir = server_config.root_dir or M.root_dir(lspconfig)
+  conf.root_dir = server_config.root_dir or M.make_root_dir(lspconfig)
 
   conf.settings.tailwindCSS = vim.tbl_get(server_config, "settings", "tailwindCSS") or {}
   conf.settings.tailwindCSS =
@@ -144,7 +144,7 @@ end
 
 ---@type fun(lspconfig: any)
 ---@return function(fname: string): string?
-M.root_dir = function(lspconfig)
+M.make_root_dir = function(lspconfig)
   return function(fname)
     local root_files = lspconfig.util.insert_package_json({
       "tailwind.config.{js,cjs,mjs,ts}",

--- a/lua/tailwind-tools/lsp.lua
+++ b/lua/tailwind-tools/lsp.lua
@@ -121,20 +121,25 @@ end
 ---@param server_config TailwindTools.ServerOption
 ---@param lspconfig { tailwindcss: lspconfig.Config }
 M.setup = function(server_config, lspconfig)
-  local config = {settings = {}}
-  config.on_attach = M.make_on_attach(server_config.on_attach)
-  config.root_dir = server_config.root_dir or M.root_dir(lspconfig)
+  local conf = { settings = {} }
+  conf.on_attach = M.make_on_attach(server_config.on_attach)
+  conf.root_dir = server_config.root_dir or M.root_dir(lspconfig)
 
-  config.settings.tailwindCSS = vim.tbl_get(server_config, "settings", "tailwindCSS") or {}
-  config.settings.tailwindCSS = vim.tbl_deep_extend('keep', config.settings.tailwindCSS, server_config.settings)
-  config.settings.tailwindCSS.includeLanguages = vim.tbl_extend('keep', server_config.settings.includeLanguages or {}, filetypes.get_server_map())
+  conf.settings.tailwindCSS = vim.tbl_get(server_config, "settings", "tailwindCSS") or {}
+  conf.settings.tailwindCSS =
+    vim.tbl_deep_extend("keep", conf.settings.tailwindCSS, server_config.settings)
+  conf.settings.tailwindCSS.includeLanguages = vim.tbl_extend(
+    "keep",
+    server_config.settings.includeLanguages or {},
+    filetypes.get_server_map()
+  )
 
-  config.capabilities = vim.lsp.protocol.make_client_capabilities()
-  config.capabilities.textDocument.colorProvider = {
+  conf.capabilities = vim.lsp.protocol.make_client_capabilities()
+  conf.capabilities.textDocument.colorProvider = {
     dynamicRegistration = true,
   }
 
-  lspconfig.tailwindcss.setup(config)
+  lspconfig.tailwindcss.setup(conf)
 end
 
 ---@type fun(lspconfig: any)


### PR DESCRIPTION
This allows the user to extend the tailwind-tools server config by adding their own `root_dir` function and `on_attach` function.

- Remove the lsp server config for `filetypes` since lspconfig seems to have a larger list -- at this point, tailwind-tools was restricting the lsp server from starting when it had support for it.
- Adjust `lsp.setup` function to extend user's passed-in functions if present. 
  - default `root_dir` function will simply be replaced by users if supplied, but I exported a `make_root_dir` in case the user wants to use it when providing their own.
  - `on_attach` will execute both the plugins and the user-supplied functions.
  - Merge in the user's supplied `includedLanguages` with the plugin's mappings.


I'm happy to split these others bits out of the PR:
- In most of the lsp functions, the `client` is already present most of the time, so I refactored some functions to accept it. When nil, it'll still try to find the client.
- Add more type annotations
- Other adjustments as you see fit

A user may configure the plugin as such:

```lua
  {
    opts = {
      server = {
        on_attach = require('myownlspconfigs').on_attach,
        root_dir = function(fname)
          local lspconfig = require('lspconfig')

          local root_file = lspconfig['tailwindcss'].config_def.default_config.root_dir(fname)
          if root_file then return root_file end

          root_file = require('tailwind-tools.lsp').make_root_dir(lspconfig)(fname)
          if root_file then return root_file end

          local mix_file = MyOwnModule.insert_mix_exs({}, 'tailwind', fname)
          return lspconfig.util.root_pattern(unpack(mix_file))(fname)
        end,
        settings = {
          includeLanguages = {
            elixir = "phoenix-heex",
            heex = "phoenix-heex",
          }
        }
      },
    }
  },

```

Resolves #73